### PR TITLE
Configure APP kernel with .env file

### DIFF
--- a/web/app.php
+++ b/web/app.php
@@ -1,13 +1,28 @@
 <?php
 
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Dotenv\Dotenv;
 
 require __DIR__.'/../vendor/autoload.php';
 if (PHP_VERSION_ID < 70000) {
     include_once __DIR__.'/../var/bootstrap.php.cache';
 }
 
-$kernel = new AppKernel('prod', false);
+// Load env file.
+(new Dotenv())->load(dirname(__DIR__) . '/.env');
+
+// Configure AppKernel variables.
+$environement = 'prod';
+$debug = false;
+$configuredEnv = getenv('SYMFONY_ENV');
+switch ($configuredEnv) {
+    case 'dev':
+        $environement = $configuredEnv;
+        $debug = true;
+        break;
+}
+
+$kernel = new AppKernel($environement, $debug);
 if (PHP_VERSION_ID < 70000) {
     $kernel->loadClassCache();
 }


### PR DESCRIPTION
Issue : https://github.com/Scopeli44/gestion-compte/issues/5

Nous pouvons désormais utiliser le fichier .env présent à la racine du projet (copier / coller le fichier .env.dist si besoin).
Le fichier n'est pas tracké par GIT.
Les données renseignées dans ce fichier sont ensuite accessibles en tant que variable d'environnement (getenv(NOM_VAR))
